### PR TITLE
[API-3491]Upgrade rails dependency in data_janitor gem.

### DIFF
--- a/data_janitor.gemspec
+++ b/data_janitor.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.2.2'
 
-  spec.add_dependency 'rails', '~> 4.2'
+  spec.add_dependency 'rails', '>= 4.2', '<= 5.1'
 
   spec.add_development_dependency 'bundler', '~> 1.10'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/lib/data_janitor/version.rb
+++ b/lib/data_janitor/version.rb
@@ -1,3 +1,3 @@
 module DataJanitor
-  VERSION = "0.3.5"
+  VERSION = "0.3.6"
 end


### PR DESCRIPTION
### Issue:
[API-3491](https://jira.westfieldlabs.com/browse/API-3491)

### Proposed Changes:
- Add rails version in  ```data_janitor.gemspec``` Upgrade rails dependency in data_janitor gem.
### Impact:

- Will this introduce any externally facing changes(endpoint, fields, validation, query)? **No**
- Any special deployment coordination needed(env changes, data/db migrations, etc.)? **No**

### Requirements:

- Test the behaviour in UAT after it's been merged, then add the "Tested in UAT" label.
- Test the behaviour in production if possible, then add the "Tested in Production" label

 @gwshaw, @kislay100 , @josedulanto