### PR TITLE
Validate strings and not lines in universal validator

### DIFF
--- a/lib/data_janitor/universal_validator.rb
+++ b/lib/data_janitor/universal_validator.rb
@@ -38,9 +38,11 @@ module DataJanitor
           # TODO: run numericality test
         when :string, :text
           if field_val.nil?
+            # Almost never does an app need to distinguish between nil and empty string, yet nil needs special handling in all cases
             report_error.call "cannot be nil. Use an empty string instead if that's what you wanted."
           else
-            report_error.call "cannot have leading/trailing whitespaces" if field_val =~ /^\s/ || field_val =~ /\s$/
+            # Our apps strings output text to the web where whitespace is meaningless
+            report_error.call "cannot have leading/trailing whitespaces" if field_val =~ /\A\s/ || field_val =~ /\s\z/
             # TODO: Should we constrain to certain encoding types?
           end
         end

--- a/lib/data_janitor/version.rb
+++ b/lib/data_janitor/version.rb
@@ -1,3 +1,3 @@
 module DataJanitor
-  VERSION = "0.3.6"
+  VERSION = "0.3.7"
 end


### PR DESCRIPTION
The universal validator uses a regex for line anchors rather than string start/end anchors and thus fails if a string contains line terminators.