### PR TITLE
Default type checking to off and add options to turn off individual checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,24 @@ rake data_janitor:cleanse[SomeModel]
 
 This will apply all the fixes that do not require semantic analysis of the data (e.g. replace `nil` values with `""` for strings)
 
+Data Janitor has the experimental ability to perform some built-in type checks, only a small part of which is implemented and currently tends to be noisy when on. It currently defaults to off. Each audit command takes an option string that defaults to 'no-type-checks' and can be set other colon-separated values to turn off specific checks. The values are:
+type-checks (or any other string not below)
+no-type-checks
+no-boolean
+no-decimal
+no-float
+no-integer
+no-string
+no-text
+no-array
+
+For example:
+```
+rake data_janitor:audit_model[SomeModel,no-string:no-boolean]
+rake data_janitor:audit[tmp/out.json,false,false,no-string:no-boolean]
+```
+
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/westfield/data_janitor.

--- a/lib/data_janitor.rb
+++ b/lib/data_janitor.rb
@@ -1,5 +1,6 @@
+require "rails"
 require "data_janitor/version"
-require 'rails'
+require "data_janitor/data_janitor"
 require "data_janitor/universal_validator"
 require "data_janitor/audit_validatable"
 

--- a/lib/data_janitor/data_janitor.rb
+++ b/lib/data_janitor/data_janitor.rb
@@ -1,0 +1,80 @@
+module DataJanitor
+  def self.audit(output_file, verbose, unscoped, options)
+    output = {}
+    all_models.each do |ar_model|
+      begin
+        audit_model ar_model, output, verbose, unscoped, options
+      rescue ActiveRecord::StatementInvalid # used to catch HABTM and schema migration. Only care about real Models
+        puts "skipping #{ar_model}"
+      end
+    end
+
+    File.write(output_file, output.to_json)
+
+    puts "Wrote results to #{output_file}"
+  end
+
+  def self.audit_model(model, output = {}, verbose = false, unscoped = false, options = 'no-type-check')
+    total = 0
+    failed = 0
+    puts "Validating: #{model.name}"
+    output[model.name] = {}
+
+    model = model.unscoped if unscoped
+    model.include(DataJanitor::UniversalValidator)
+    model.validate do |record|
+      record.validate_field_values options
+    end
+
+    model.find_each do |rec|
+      if rec.invalid?(:dj_audit)
+        rec.errors.to_h.each_pair do |attribute, error_message|
+          output[model.name][attribute] ||= {}
+          output[model.name][attribute][error_message] ||= []
+          output[model.name][attribute][error_message] << rec.id
+        end
+
+        failed += 1
+      end
+
+      total += 1
+    end
+
+    puts output.to_json if verbose
+    puts "Completed #{total} records with #{failed} failures"
+  end
+
+  def self.cleanse
+    all_models.each do |ar_model|
+      cleanse_model! ar_model
+    end
+  end
+
+  def self.cleanse_model(model)
+    cleanse_model! model.constantize
+  end
+
+  private
+
+  def self.all_models
+    # Needs this executed before here: Rails.application.eager_load!
+    ActiveRecord::Base.descendants
+  end
+
+  def self.cleanse_model!(model)
+    string_columns = model.columns.select{|c| (c.type == :string || c.type == :text) && c.array == false}
+    boolean_columns = model.columns.select{|c| c.type == :boolean && c.array == false}
+    array_columns = model.columns.select{|c| c.array == true}
+
+    clean_nils_from! model, string_columns, ""
+    clean_nils_from! model, boolean_columns, false
+    clean_nils_from! model, array_columns, []
+  end
+
+  def self.clean_nils_from!(model, columns, default)
+    columns.each do |column|
+      count = model.where(column.name => nil).update_all(column.name => default)
+      puts "Fixed #{count} #{model} records where #{column.name} was nil" if count > 0
+    end
+  end
+end

--- a/lib/data_janitor/universal_validator.rb
+++ b/lib/data_janitor/universal_validator.rb
@@ -4,21 +4,26 @@ module DataJanitor
     # TODO: Run standard validators instead of home-brewed
     # validate :validate_field_values
     # ACCEPTABLE_BOOLEAN_VALUES = %w(t true y yes on 1 f false n no off 0) # this list was taken from Postgres spec. TRUE FALSE, that are also there, are not listed because they are DB-native literals and have no representation in Ruby code
-    def validate_field_values
+    def validate_field_values(options)
+      optional = options.split(':').map(&:strip)
+      return if optional.include? 'no-type-check'
+
       # selected_attributes = self.changed? ? self.changed_attributes : self.attributes
       selected_attributes = self.attributes
 
       selected_attributes.each do |field_name, field_val|
         column = self.column_for_attribute field_name
-        report_error = lambda {|msg| errors[column.name] << msg}
+        report_error = lambda { |msg| errors[column.name] << msg }
 
         if column.array
+          next if optional.include? 'no-array'
           report_error.call "cannot be nil" if field_val.nil?
           next
         end
 
         case column.type
         when :boolean
+          next if optional.include? 'no-boolean'
           report_error.call "cannot be nil" if field_val.nil?
           # report_error.call("must be a valid boolean") unless ACCEPTABLE_BOOLEAN_VALUES.include? field_val
         when :date
@@ -28,15 +33,19 @@ module DataJanitor
         when :datetime
           # Time.iso8601(field_val) rescue report_error.call("must be a datetime in ISO-8601")
         when :decimal
+          next if optional.include? 'no-decimal'
           report_error.call "cannot be nil" if field_val.nil?
           # TODO: run numericality test
         when :float
+          next if optional.include? 'no-float'
           report_error.call "cannot be nil" if field_val.nil?
           # TODO: run numericality test
         when :integer
+          next if optional.include? 'no-integer'
           report_error.call "cannot be nil" if field_val.nil?
           # TODO: run numericality test
         when :string, :text
+          next if optional.include?('no-string') || optional.include?('no-text')
           if field_val.nil?
             # Almost never does an app need to distinguish between nil and empty string, yet nil needs special handling in all cases
             report_error.call "cannot be nil. Use an empty string instead if that's what you wanted."

--- a/lib/data_janitor/version.rb
+++ b/lib/data_janitor/version.rb
@@ -1,3 +1,3 @@
 module DataJanitor
-  VERSION = "0.3.7"
+  VERSION = "0.4.0"
 end

--- a/lib/tasks/data_janitor.rake
+++ b/lib/tasks/data_janitor.rake
@@ -1,30 +1,26 @@
 namespace :data_janitor do
   desc 'Summarize invalid database records'
-  task :audit, [:output_file, :verbose, :unscoped] => [:environment] do |_t, args|
+  task :audit, [:output_file, :verbose, :unscoped, :options] => [:environment] do |_t, args|
     args.with_defaults(
       output_file: Rails.root.join('tmp', 'data_janitor_results.json'),
-      verbose: false,
-      unscoped: false
+      verbose: 'false',
+      unscoped: 'false',
+      options: 'no-type-check'
     )
+    verbose = args[:verbose] == 'true'
+    unscoped = args[:unscoped] == 'true'
 
-    output = {}
-    all_models.each do |ar_model|
-      begin
-        audit ar_model, output, args[:verbose], args[:unscoped]
-      rescue ActiveRecord::StatementInvalid # used to catch HABTM and schema migration. Only care about real Models
-        puts "skipping #{ar_model}"
-      end
-    end
-
-    File.write(args[:output_file], output.to_json)
-
-    puts "Wrote results to #{args[:output_file]}"
+    Rails.application.eager_load!
+    DataJanitor::audit(args[:output_file], verbose, unscoped, args[:options])
   end
 
   desc 'Audit one model for data issues'
-  task :audit_model, [:model] => [:environment] do |_t, args|
+  task :audit_model, [:model, :options] => [:environment] do |_t, args|
+    args.with_defaults(
+      options: 'no-type-check'
+    )
     Rails.application.eager_load!
-    audit args[:model].constantize, {}, true
+    DataJanitor::audit_model args[:model].constantize, {}, true, false, args[:options]
   end
 
   # For each model, apply trivial data corrections (those that do not require looking at data semantics).
@@ -34,67 +30,14 @@ namespace :data_janitor do
   # - replace all null arrays with []
   desc 'Apply common and safe data corrections'
   task cleanse: :environment do
-    all_models.each do |ar_model|
-      cleanse_model! ar_model
-    end
+    Rails.application.eager_load!
+    DataJanitor::clense
   end
 
   desc 'Apply fixes to one model only'
   task :cleanse_model, [:model] => [:environment] do |_t, args|
     Rails.application.eager_load!
-
-    cleanse_model! args[:model].constantize
+    DataJanitor::clense_model args[:model].constantize
   end
 
-  private
-
-  def all_models
-    Rails.application.eager_load!
-    ActiveRecord::Base.descendants
-  end
-
-  def audit(model, output = {}, verbose = false, unscoped = false)
-    total = 0
-    failed = 0
-    puts "Validating: #{model.name}"
-    output[model.to_s] = {}
-    model = model.unscoped if unscoped
-
-    model.include(DataJanitor::UniversalValidator)
-    model.validate :validate_field_values
-
-    model.find_each do |rec|
-      if rec.invalid?(:dj_audit)
-        rec.errors.to_h.each_pair do |attribute, error_message|
-          output[model.to_s][attribute] ||= {}
-          output[model.to_s][attribute][error_message] ||= []
-          output[model.to_s][attribute][error_message] << rec.id
-        end
-
-        failed += 1
-      end
-
-      total += 1
-    end
-
-    puts output.to_json if verbose
-    puts "Completed #{total} records with #{failed} failures"
-  end
-
-  def cleanse_model!(model)
-    string_columns = model.columns.select{|c| (c.type == :string || c.type == :text) && c.array == false}
-    boolean_columns = model.columns.select{|c| c.type == :boolean && c.array == false}
-    array_columns = model.columns.select{|c| c.array == true}
-
-    clean_nils_from! model, string_columns, ""
-    clean_nils_from! model, boolean_columns, false
-    clean_nils_from! model, array_columns, []
-  end
-
-  def clean_nils_from!(model, columns, default)
-    columns.each do |column|
-      count = model.where(column.name => nil).update_all(column.name => default)
-      puts "Fixed #{count} #{model} records where #{column.name} was nil" if count > 0
-    end
-  end
 end


### PR DESCRIPTION
Fixes bug related to setting verbose and unscoped options.
Refactors code to a module for namespacing and later ability to add tests.
Adds an options argument to be able to turn-off type-checking individually
Defaults to type checking off as it is noisy and string checks not currently useful.